### PR TITLE
fix(docker): resolve Python 3.12 build compatibility issues

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,56 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Virtual environments
+venv/
+env/
+ENV/
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Git
+.git/
+.gitignore
+
+# Docker
+Dockerfile*
+docker-compose*
+
+# Documentation
+docs/
+*.md
+README*
+
+# Tests
+tests/
+
+# Logs
+*.log 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,25 @@
 FROM python:3.12-slim
 
+# Install system dependencies and build tools
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    gcc \
+    g++ \
+    && rm -rf /var/lib/apt/lists/*
+
+# Upgrade pip and install setuptools
+RUN python3 -m pip install --upgrade pip setuptools wheel
+
+# Set working directory
+WORKDIR /app
+
+# Copy requirements first for better caching
+COPY requirements.txt .
+
+# Install Python dependencies
+RUN python3 -m pip install -r requirements.txt
+
+# Copy the rest of the application
 COPY . .
 
-RUN python3 -m pip install -r requirements.txt
 ENTRYPOINT ["python3","blackbird.py"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ MarkupSafe==2.1.5
 mdurl==0.1.2
 multidict==6.1.0
 murmurhash==1.0.13
-numpy==1.24.4
+numpy==1.26.4
 packaging==25.0
 pillow==10.4.0
 preshed==3.0.10


### PR DESCRIPTION
- Add build dependencies (build-essential, gcc, g++) to Dockerfile
- Upgrade numpy from 1.24.4 to 1.26.4 for Python 3.12 support
- Add .dockerignore to optimize build context
- Improve layer caching in Dockerfile
- Fix setuptools.build_meta import error during pip install

Resolves Docker build failures with Python 3.12 slim image.